### PR TITLE
Update some natives found in decompiled scripts

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -109005,7 +109005,7 @@
 					"name": "p3"
 				}
 			],
-			"return_type": "void",
+			"return_type": "int",
 			"build": "1207"
 		},
 		"0xCEDBF17EFCC0E4A4": {

--- a/natives.json
+++ b/natives.json
@@ -29050,19 +29050,19 @@
 			"build": "1207"
 		},
 		"0xD8402B858F4DDD88": {
-			"name": "_0xD8402B858F4DDD88",
+			"name": "GET_TEXT_SUBSTRING_2",
 			"comment": "",
 			"params": [
 				{
-					"type": "Any",
-					"name": "p0"
+					"type": "const char*",
+					"name": "text"
 				},
 				{
-					"type": "Any",
-					"name": "p1"
+					"type": "int",
+					"name": "length"
 				}
 			],
-			"return_type": "Any",
+			"return_type": "char*",
 			"build": "1207"
 		},
 		"0x806862E5D266CF38": {
@@ -33521,16 +33521,16 @@
 			"build": "1311"
 		},
 		"0xA6AA9F56BC6CFF58": {
-			"name": "_0xA6AA9F56BC6CFF58",
+			"name": "INVENTORY_ENABLE_MISSION_INVENTORY",
 			"comment": "",
 			"params": [
 				{
-					"type": "Any",
-					"name": "p0"
+					"type": "BOOL",
+					"name": "enable"
 				},
 				{
-					"type": "Any",
-					"name": "p1"
+					"type": "BOOL",
+					"name": "mirrorTransactions"
 				}
 			],
 			"return_type": "void",
@@ -33604,10 +33604,10 @@
 			"build": "1207"
 		},
 		"0xFC7563F482781A3D": {
-			"name": "_0xFC7563F482781A3D",
+			"name": "IS_INVENTORY_MIRROING_TRANSACTIONS",
 			"comment": "",
 			"params": [],
-			"return_type": "Any",
+			"return_type": "BOOL",
 			"build": "1207"
 		},
 		"0xC04F47D488EF9EBA": {
@@ -34224,15 +34224,15 @@
 			"build": "1207"
 		},
 		"0xCBB7B6EDFA933ADE": {
-			"name": "_0xCBB7B6EDFA933ADE",
+			"name": "ITEMDATABASE_SET_ITEM_COLLECTION_DISCOUNTED",
 			"comment": "",
 			"params": [
 				{
-					"type": "Any",
-					"name": "p0"
+					"type": "int",
+					"name": "collection"
 				}
 			],
-			"return_type": "Any",
+			"return_type": "void",
 			"build": "1207"
 		},
 		"0x337F88E3A063995E": {
@@ -35204,19 +35204,19 @@
 			"build": "1207"
 		},
 		"0xF4452CE83118C738": {
-			"name": "_0xF4452CE83118C738",
+			"name": "GET_INVENTORY_ITEM_PATHSET",
 			"comment": "",
 			"params": [
 				{
-					"type": "Any",
-					"name": "p0"
+					"type": "int",
+					"name": "item"
 				},
 				{
-					"type": "Any",
+					"type": "int",
 					"name": "p1"
 				}
 			],
-			"return_type": "Any",
+			"return_type": "int",
 			"build": "1207"
 		},
 		"0xAA29A5F13B2C20B2": {
@@ -108989,12 +108989,12 @@
 			"comment": "Example : https://pastebin.com/h1YzycuR",
 			"params": [
 				{
-					"type": "Any*",
-					"name": "p0"
+					"type": "int*",
+					"name": "duration"
 				},
 				{
 					"type": "Any*",
-					"name": "p1"
+					"name": "data"
 				},
 				{
 					"type": "BOOL",
@@ -109005,7 +109005,7 @@
 					"name": "p3"
 				}
 			],
-			"return_type": "Any",
+			"return_type": "void",
 			"build": "1207"
 		},
 		"0xCEDBF17EFCC0E4A4": {


### PR DESCRIPTION
Found these natives while working on decompiled scripts :
- GET_TEXT_SUBSTRING_2 (HUD::_0xD8402B858F4DDD88)
- INVENTORY_ENABLE_MISSION_INVENTORY (INVENTORY::_0xA6AA9F56BC6CFF58)
- IS_INVENTORY_MIRROING_TRANSACTIONS (INVENTORY::_0xFC7563F482781A3D)
- ITEMDATABASE_SET_ITEM_COLLECTION_DISCOUNTED (ITEMDATABASE::_0xCBB7B6EDFA933ADE)
- GET_INVENTORY_ITEM_PATHSET (ITEMDATABASE::_0xF4452CE83118C738)

Also named some parameters in UIFEED::_UI_FEED_POST_LOCATION_SHARD and return type